### PR TITLE
link to local evaluation files

### DIFF
--- a/Proyectos-Finalistas.md
+++ b/Proyectos-Finalistas.md
@@ -37,8 +37,8 @@ Decred Memories | https://github.com/aeh-bonilla/decred-memories-api | https://y
 
 ## Resultados de la Evaluación
 
-Proyecto | [Ammarooni](https://github.com/DecredES/Challenge/issues/1) | [bee](https://gist.github.com/xaur/ccedac5b9c8d62430efd317bc1e8ccda) | [Dave](https://gist.github.com/davecgh/83be30f0f54ea2ef1154225476ada368) | [Juan Cancino](evaluation-juan-cancino.md) | Puntaje
---- | ---- | ---- | --- | --- | --- 
+Proyecto | [Ammarooni](evaluation-ammarooni.md) | [bee](evaluation-bee.md) | [Dave](evaluation-davecgh.md) | [Juan Cancino](evaluation-juan-cancino.md) | Puntaje
+---|--:|--:|--:|--:|--:
 Digital Identity | 56 | 35 | 49 | 66 | 52
 People of Pi | 81 | 76 | 79 | 89 | 81
 Bitmoney | 65 | 38 | 46 | 62 | 53


### PR DESCRIPTION
Change links in the finals report to point to local evaluation files
that were recently imported, in order to reduce dependencies on
external sources.

While there, also right-align numeric columns.