### PR TITLE
consistent metadata for evaluations

### DIFF
--- a/evaluation-ammarooni.md
+++ b/evaluation-ammarooni.md
@@ -1,6 +1,7 @@
 ---
 author: ammarooni
-published_utc: 2020-12-08
+published_utc: 2020-12-08 04:19
+updated_utc: 2020-12-14 17:33
 ---
 
 # Evaluation by ammarooni

--- a/evaluation-bee.md
+++ b/evaluation-bee.md
@@ -1,3 +1,9 @@
+---
+author: bee
+published_utc: 2020-12-07 03:53
+updated_utc: 2020-12-12 00:53
+---
+
 # Evaluation by bee
 
 This is my evaluation of 6 final project for Decred Blockchain Learning Challenge, Oct-Dec 2020.

--- a/evaluation-davecgh.md
+++ b/evaluation-davecgh.md
@@ -1,3 +1,9 @@
+---
+author: davecgh
+published_utc: 2020-12-07 13:54
+updated_utc: 2020-12-17 04:14
+---
+
 # Puntuación
 
 Proyecto | Adquisición y utilización de datos | Relevancia y conclusiones específicas de Decred | Funcionalidad, facilidad de uso y accesibilidad | Ejecución | Documentación | Total

--- a/evaluation-juan-cancino.md
+++ b/evaluation-juan-cancino.md
@@ -1,3 +1,9 @@
+---
+author: Juan Cancino
+published_utc: 2020-12-09 20:13
+updated_utc: 2020-12-22 17:46
+---
+
 # Evaluation by Juan Cancino
 
 Proyecto | Procuración/uso de datos | Relevancia y Hallazgos DECRED | Funcionalidad, Usabilidad, Escalibilidad | Ejecución | Documentación | Promedio final


### PR DESCRIPTION
Add missing author name and published/updated timestamps to the
beginning of evaluation files. Timestamps were extracted from original
gists (bee, davecgh), Git commit to this repo (Juan), and GitHub issue
(ammarooni).

The motivation for adding this is that it contributes to transparency
and audit trail of events, which in turn adds credibility to judgement
results of public contests like this.

Metadata uses the "front-matter" syntax that originated from Jekyll
site generator ( https://jekyllrb.com/docs/front-matter/ ), but turned
out to be very useful in general. It is essentially a bit of YAML at
the beginning of Markdown files.